### PR TITLE
Improve C implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,10 @@ rake compile
 
 irb -r base64 -r ./lib/aes256gcm_decrypt.so
 
-token_data = Base64.decode64(File.read('test/token_data_base64.txt'))
-ciphertext = token_data[0..-17]
-tag = token_data[-16..-1]
+ciphertext_and_tag = Base64.decode64(File.read('test/token_data_base64.txt'))
 key = Base64.decode64(File.read('test/key_base64.txt'))
 
-puts Aes256GcmDecrypt::decrypt(ciphertext, tag, key)
+puts Aes256GcmDecrypt::decrypt(ciphertext_and_tag, key)
 ```
 
 ## Inspirational sources

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ key = Base64.decode64(File.read('test/key_base64.txt'))
 puts Aes256GcmDecrypt::decrypt(ciphertext_and_tag, key)
 ```
 
+`#decrypt` returns a string with plaintext if authenticated decryption is successful. If the authentication part is unsuccessful, it returns `false`. If anything is wrong, e.g. the length of `key` is not 32, it returns `nil`.
+
 ## Inspirational sources
 
 * [Your first Ruby native extension: C](https://blog.jcoglan.com/2012/07/29/your-first-ruby-native-extension-c/)

--- a/ext/aes256gcm_decrypt/aes256gcm_decrypt.c
+++ b/ext/aes256gcm_decrypt/aes256gcm_decrypt.c
@@ -63,11 +63,6 @@ VALUE method_aes256gcm_decrypt_decrypt(VALUE self, VALUE rb_ciphertext_and_tag, 
     goto cleanup3;
   }
 
-  /* Provide empty string as additional authenticated data (AAD) */
-  if (!EVP_DecryptUpdate(ctx, NULL, &len, (unsigned char *)"", 0)) {
-    goto cleanup3;
-  }
-
   /* Provide message to be decrypted */
   if (!EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, ciphertext_len)) {
     goto cleanup3;

--- a/ext/aes256gcm_decrypt/aes256gcm_decrypt.c
+++ b/ext/aes256gcm_decrypt/aes256gcm_decrypt.c
@@ -80,7 +80,7 @@ VALUE method_aes256gcm_decrypt_decrypt(VALUE self, VALUE rb_ciphertext_and_tag, 
   }
 
   /* Finalise decryption */
-  if (EVP_DecryptFinal_ex(ctx, plaintext + len, &len) > 0) {
+  if (EVP_DecryptFinal_ex(ctx, &plaintext[len], &len) > 0) {
     plaintext_len += len;
     if (plaintext_len > ciphertext_len + 16) {
       fprintf(stderr, "Plaintext overflow in AES256GCM decryption! Aborting.\n");

--- a/ext/aes256gcm_decrypt/aes256gcm_decrypt.c
+++ b/ext/aes256gcm_decrypt/aes256gcm_decrypt.c
@@ -24,8 +24,7 @@ VALUE method_aes256gcm_decrypt_decrypt(VALUE self, VALUE rb_ciphertext_and_tag, 
   memcpy(ciphertext, rb_ciphertext_p, ciphertext_len);
 
   unsigned char *tag = calloc(tag_len, sizeof(unsigned char));
-  char *rb_tag_p = rb_ciphertext_p + sizeof(unsigned char) * ciphertext_len;
-  memcpy(tag, rb_tag_p, tag_len);
+  memcpy(tag, &rb_ciphertext_p[ciphertext_len], tag_len);
 
   unsigned int key_len = RSTRING_LEN(rb_key);
   if (key_len != 32) {

--- a/ext/aes256gcm_decrypt/aes256gcm_decrypt.c
+++ b/ext/aes256gcm_decrypt/aes256gcm_decrypt.c
@@ -4,36 +4,43 @@
 #include <string.h>
 #include <openssl/evp.h>
 
-VALUE Aes256GcmDecrypt = Qnil;
-
-VALUE method_aes256gcm_decrypt_decrypt(VALUE self, VALUE rb_ciphertext, VALUE rb_tag, VALUE rb_key) {
-  Check_Type(rb_ciphertext, T_STRING);
-  Check_Type(rb_tag, T_STRING);
+VALUE method_aes256gcm_decrypt_decrypt(VALUE self, VALUE rb_ciphertext_and_tag, VALUE rb_key) {
+  Check_Type(rb_ciphertext_and_tag, T_STRING);
   Check_Type(rb_key, T_STRING);
 
   /* Prepare variables */
-  unsigned int ciphertext_len = RSTRING_LEN(rb_ciphertext);
-  unsigned char *ciphertext = calloc(ciphertext_len, sizeof(unsigned char));
-  memcpy(ciphertext, StringValuePtr(rb_ciphertext), ciphertext_len);
+  VALUE result = Qnil;
 
-  unsigned int tag_len = RSTRING_LEN(rb_tag);
+  unsigned int tag_len = 16;
+  unsigned int ciphertext_and_tag_len = RSTRING_LEN(rb_ciphertext_and_tag);
+  if (ciphertext_and_tag_len <= tag_len) {
+    goto exit;
+  }
+
+  unsigned int ciphertext_len = ciphertext_and_tag_len - tag_len;
+
+  unsigned char *ciphertext = calloc(ciphertext_len, sizeof(unsigned char));
+  char *rb_ciphertext_p = StringValuePtr(rb_ciphertext_and_tag);
+  memcpy(ciphertext, rb_ciphertext_p, ciphertext_len);
+
   unsigned char *tag = calloc(tag_len, sizeof(unsigned char));
-  memcpy(tag, StringValuePtr(rb_tag), tag_len);
+  char *rb_tag_p = rb_ciphertext_p + sizeof(unsigned char) * ciphertext_len;
+  memcpy(tag, rb_tag_p, tag_len);
 
   unsigned int key_len = RSTRING_LEN(rb_key);
+  if (key_len != 32) {
+    goto cleanup1;
+  }
+
   unsigned char *key = calloc(key_len, sizeof(unsigned char));
   memcpy(key, StringValuePtr(rb_key), key_len);
 
   unsigned int iv_len = 16;
-  unsigned char *iv = calloc(iv_len, sizeof(unsigned char));
-  for (int i = 0; i < iv_len; i++) {
-    iv[i] = '\0';
-  }
+  unsigned char iv[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
-  unsigned int plaintext_len, len;
-  unsigned char *plaintext = calloc(ciphertext_len * 2, sizeof(unsigned char));
+  int plaintext_len, len;
+  unsigned char *plaintext = calloc(ciphertext_len + 16, sizeof(unsigned char));
 
-  VALUE result = Qnil;
   EVP_CIPHER_CTX *ctx;
 
   /* Create and initialise context */
@@ -43,55 +50,60 @@ VALUE method_aes256gcm_decrypt_decrypt(VALUE self, VALUE rb_ciphertext, VALUE rb
 
   /* Initialise decryption operation */
   if (!EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL)) {
-    goto cleanup1;
+    goto cleanup3;
   }
 
   /* Set initialisation vector (IV) length */
   if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, iv_len, NULL)) {
-    goto cleanup1;
+    goto cleanup3;
   }
 
   /* Initialise key and IV */
   if (!EVP_DecryptInit_ex(ctx, NULL, NULL, key, iv)) {
-    goto cleanup1;
+    goto cleanup3;
   }
 
   /* Provide empty string as additional authenticated data (AAD) */
-  if (!EVP_DecryptUpdate(ctx, NULL, &len, "", 0)) {
-    goto cleanup1;
+  if (!EVP_DecryptUpdate(ctx, NULL, &len, (unsigned char *)"", 0)) {
+    goto cleanup3;
   }
 
   /* Provide message to be decrypted */
   if (!EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, ciphertext_len)) {
-    goto cleanup1;
+    goto cleanup3;
   }
   plaintext_len = len;
 
   /* Set expected tag */
   if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, tag_len, tag)) {
-    goto cleanup1;
+    goto cleanup3;
   }
 
   /* Finalise decryption */
   if (EVP_DecryptFinal_ex(ctx, plaintext + len, &len) > 0) {
     plaintext_len += len;
-    result = rb_str_new(plaintext, plaintext_len);
+    if (plaintext_len > ciphertext_len + 16) {
+      fprintf(stderr, "Plaintext overflow in AES256GCM decryption! Aborting.\n");
+      abort();
+    }
+    result = rb_str_new((char *)plaintext, plaintext_len);
   } else {
     result = Qfalse;
   }
 
-cleanup1:
+cleanup3:
   EVP_CIPHER_CTX_free(ctx);
 cleanup2:
   free(plaintext);
-  free(iv);
   free(key);
+cleanup1:
   free(tag);
   free(ciphertext);
+exit:
   return result;
 }
 
 void Init_aes256gcm_decrypt() {
-  Aes256GcmDecrypt = rb_define_module("Aes256GcmDecrypt");
-  rb_define_singleton_method(Aes256GcmDecrypt, "decrypt", method_aes256gcm_decrypt_decrypt, 3);
+  VALUE Aes256GcmDecrypt = rb_define_module("Aes256GcmDecrypt");
+  rb_define_singleton_method(Aes256GcmDecrypt, "decrypt", method_aes256gcm_decrypt_decrypt, 2);
 }

--- a/ext/aes256gcm_decrypt/extconf.rb
+++ b/ext/aes256gcm_decrypt/extconf.rb
@@ -1,5 +1,6 @@
 require 'mkmf'
 extension_name = 'aes256gcm_decrypt'
 dir_config(extension_name)
+$CFLAGS << ' -Wall'
 $LDFLAGS << ' -lcrypto'
 create_makefile(extension_name)


### PR DESCRIPTION
* Combine `ciphertext` and `tag` parameters
* Compile with `-Wall`
* Hardcode `iv` rather than dynamically allocating it
* Allocate less memory for `plaintext`
* Do a segmentation fault if we have written beyond `plaintext`
* Reverse the order of the `cleanupX` labels


Closes #2 
Closes #3 
  