### PR TITLE
Prepare for RubyGems.org publication

### DIFF
--- a/aes256gcm_decrypt.gemspec
+++ b/aes256gcm_decrypt.gemspec
@@ -1,13 +1,16 @@
 Gem::Specification.new do |s|
-  s.name    = 'aes256gcm_decrypt'
-  s.version = '0.0.1'
-  s.summary = 'Decrypt AES256GCM-encrypted data in Apple Pay Payment Tokens'
-  s.author  = 'Clearhaus'
+  s.name     = 'aes256gcm_decrypt'
+  s.version  = '0.0.2'
+  s.summary  = 'Decrypt AES256GCM-encrypted data in Apple Pay Payment Tokens'
+  s.author   = 'Clearhaus'
+  s.homepage = 'https://github.com/clearhaus/aes256gcm_decrypt'
+  s.license  = 'MIT'
 
-  s.files = Dir.glob("ext/**/*.{c,rb}") +
-            Dir.glob("lib/**/*.rb")
+  s.files    = `git ls-files -z`.split("\x0")
 
   s.extensions << "ext/aes256gcm_decrypt/extconf.rb"
+
+  s.required_ruby_version = '< 2.4'
 
   s.add_development_dependency "rake-compiler"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
I pushed 0.0.1, and repushing of gem versions is not allowed, hence the update to 0.0.2.